### PR TITLE
changes to allow vignette to build with R CMD build; assume rmarkdown…

### DIFF
--- a/vignettes/bioc2015rnaseq.Rmd
+++ b/vignettes/bioc2015rnaseq.Rmd
@@ -2,6 +2,11 @@
 title: "Differential expression, manipulation, and visualization of RNA-seq reads"
 author: "Michael Love, Simon Anders, Wolfgang Huber"
 date: "21 July 2015" 
+vignette: >
+  %\VignetteIndexEntry{Differential expression, manipulation, and visualization of RNA-seq reads}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+
 ---
 
 ```{r opts, echo=FALSE, results="hide"}


### PR DESCRIPTION
… is desired

Hi,

as it stands, `R CMD build` does not build the vignette in this package. I added code to make sure it does, and since BiocStyle is in Suggests, I assume you want to use it so I made the appropriate change. Accepting this pull request will allow the vignettes to be installed when I install the package on the AMI using the special biocLite() command that I sent out.
